### PR TITLE
Allow to use URLs without a host

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,7 +62,7 @@ class E2eTest extends PanthereTestCase
     public function testMyApp()
     {
         $client = static::createPanthereClient(); // Your app is automatically started using the built-in web server
-        $crawler = $client->request('GET', static::$baseUri.'/mypage'); // static::$baseUri contains the base URL
+        $crawler = $client->request('GET', '/mypage');
 
         $this->assertContains('My Title', $crawler->filter('title')->text()); // You can use any PHPUnit assertion
     }

--- a/src/PanthereTestCase.php
+++ b/src/PanthereTestCase.php
@@ -14,6 +14,7 @@ declare(strict_types=1);
 namespace Panthere;
 
 use Goutte\Client as GoutteClient;
+use GuzzleHttp\Client as GuzzleClient;
 use Panthere\Client as PanthereClient;
 use Panthere\ProcessManager\WebServerManager;
 use PHPUnit\Framework\TestCase;
@@ -105,7 +106,7 @@ abstract class PanthereTestCase extends InternalTestCase
     {
         self::startWebServer(null, $hostname, $port);
         if (null === self::$panthereClient) {
-            self::$panthereClient = Client::createChromeClient();
+            self::$panthereClient = Client::createChromeClient(null, null, [], self::$baseUri);
         }
 
         return self::$panthereClient;
@@ -119,7 +120,10 @@ abstract class PanthereTestCase extends InternalTestCase
 
         self::startWebServer();
         if (null === self::$goutteClient) {
-            self::$goutteClient = new GoutteClient();
+            $goutteClient = new GoutteClient();
+            $goutteClient->setClient(new GuzzleClient(['base_uri' => self::$baseUri]));
+
+            self::$goutteClient = $goutteClient;
         }
 
         return self::$goutteClient;

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -39,6 +39,6 @@ abstract class TestCase extends PanthereTestCase
 
     protected function request(callable $clientFactory, string $path): Crawler
     {
-        return $clientFactory()->request('GET', static::$baseUri.$path);
+        return $clientFactory()->request('GET', $path);
     }
 }


### PR DESCRIPTION
It will improve the testing experience, and provide a better compatibility with existing `WebTestCase`-bases tests.
This PR requires FriendsOfPHP/Goutte#349 for Goutte support.