### PR TITLE
Allow using an env var to determine chrome driver binary

### DIFF
--- a/README.md
+++ b/README.md
@@ -145,6 +145,7 @@ The following environment variables can be set to change some Panthère behavior
 * `PANTHERE_NO_HEADLESS`: to disable browsers's headless mode (will display the testing window, useful to debug)
 * `PANTHERE_NO_SANDBOX`: to disable [Chrome's sandboxing](https://chromium.googlesource.com/chromium/src/+/b4730a0c2773d8f6728946013eb812c6d3975bec/docs/design/sandbox.md) (unsafe, but allows to use Panthère in containers)
 * `PANTHERE_WEB_SERVER_DIR`: to change the project's document root (default to `public/`)
+* `PANTHERE_CHROME_DRIVER_BINARY`: to use another `chromedriver` binary, instead of relying on the ones already provided by Panthère
 
 ## Docker Integration
 

--- a/src/ProcessManager/ChromeManager.php
+++ b/src/ProcessManager/ChromeManager.php
@@ -32,7 +32,7 @@ final class ChromeManager implements BrowserManagerInterface
 
     public function __construct(?string $chromeDriverBinary = null, ?array $arguments = null, array $options = [])
     {
-        $this->process = new Process([$chromeDriverBinary ?? $this->findChromeDriverBinary()], null, null, null, null);
+        $this->process = new Process([$chromeDriverBinary ?: $this->findChromeDriverBinary()], null, null, null, null);
         $this->arguments = $arguments ?? $this->getDefaultArguments();
         $this->options = \array_merge($this->getDefaultOptions(), $options);
     }
@@ -66,6 +66,10 @@ final class ChromeManager implements BrowserManagerInterface
 
     private function findChromeDriverBinary(): string
     {
+        if ($binary = $_SERVER['PANTHERE_CHROME_DRIVER_BINARY'] ?? null) {
+            return $binary;
+        }
+
         switch (PHP_OS_FAMILY) {
             case 'Windows':
                 return __DIR__.'/../../chromedriver-bin/chromedriver.exe';


### PR DESCRIPTION
My problem is that Panthère doesn't work on Alpine (because on Alpine we should either use the driver coming from the repository, or recompile it manually).

For this, it could be nice to tell Alpine users to use either the package or to recompile it instead of using Panthère's provided binary. And in general, to get the latest version, it's better to propose them to download the package in another way, for them to be sure 😅.

For now, an env var is the best solution to use another binary, to me. 

WDYT?